### PR TITLE
Expose DatasetBuilder and add kwargs for convenient instantiation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@
 plugins {
     alias(libs.plugins.kotlin)
     alias(libs.plugins.modl)
-    // alias(libs.plugins.dokka) TODO: Investigate Dokka for automatic generation of module docs
 }
 
 subprojects {
@@ -21,10 +20,10 @@ ignitionModule {
 
     projectScopes.putAll(
         mapOf(
-            ":client" to "C",
-            ":common" to "GDC",
-            ":designer" to "D",
-            ":gateway" to "G",
+            projects.common.dependencyProject.path to "GDC",
+            projects.gateway.dependencyProject.path to "G",
+            projects.designer.dependencyProject.path to "D",
+            projects.client.dependencyProject.path to "C",
         ),
     )
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -3,14 +3,10 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-    }
-}
-
 kotlin {
-    jvmToolchain(libs.versions.java.map(String::toInt).get())
+    jvmToolchain {
+        languageVersion.set(libs.versions.java.map(JavaLanguageVersion::of))
+    }
 }
 
 dependencies {

--- a/client/src/main/kotlin/org/imdc/extensions/client/ClientHook.kt
+++ b/client/src/main/kotlin/org/imdc/extensions/client/ClientHook.kt
@@ -8,6 +8,7 @@ import com.inductiveautomation.ignition.common.script.ScriptManager
 import com.inductiveautomation.vision.api.client.AbstractClientModuleHook
 import org.imdc.extensions.common.DatasetExtensions
 import org.imdc.extensions.common.ExtensionDocProvider
+import org.imdc.extensions.common.PyDatasetBuilder
 import org.imdc.extensions.common.UtilitiesExtensions
 import org.imdc.extensions.common.addPropertyBundle
 import org.imdc.extensions.common.expressions.IsAvailableFunction
@@ -24,6 +25,12 @@ class ClientHook : AbstractClientModuleHook() {
             addPropertyBundle<UtilitiesExtensions>()
             addPropertyBundle<ClientProjectExtensions>()
         }
+
+        PyDatasetBuilder.register()
+    }
+
+    override fun shutdown() {
+        PyDatasetBuilder.unregister()
     }
 
     override fun initializeScriptManager(manager: ScriptManager) {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,14 +3,10 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-    }
-}
-
 kotlin {
-    jvmToolchain(libs.versions.java.map(String::toInt).get())
+    jvmToolchain {
+        languageVersion.set(libs.versions.java.map(JavaLanguageVersion::of))
+    }
 }
 
 dependencies {

--- a/common/src/main/kotlin/org/imdc/extensions/common/PyDatasetBuilder.kt
+++ b/common/src/main/kotlin/org/imdc/extensions/common/PyDatasetBuilder.kt
@@ -4,6 +4,7 @@ import com.inductiveautomation.ignition.common.Dataset
 import com.inductiveautomation.ignition.common.script.DisposablePyObjectAdapter
 import com.inductiveautomation.ignition.common.util.DatasetBuilder
 import com.inductiveautomation.ignition.common.xmlserialization.ClassNameResolver
+import org.imdc.extensions.common.DatasetExtensions.asJavaClass
 import org.python.core.Py
 import org.python.core.PyObject
 import org.python.core.adapter.PyObjectAdapter
@@ -20,12 +21,8 @@ class PyDatasetBuilder(private val builder: DatasetBuilder) : PyObject() {
         builder.colNames(names)
     }
 
-    fun colTypes(vararg types: String) = apply {
-        builder.colTypes(types.map { resolver.classForName(it) })
-    }
-
-    fun colTypes(vararg types: Class<*>?) = apply {
-        builder.colTypes(types.toList())
+    fun colTypes(vararg types: PyObject) = apply {
+        builder.colTypes(types.map { it.asJavaClass() })
     }
 
     fun colTypes(types: List<Class<*>>) = apply {

--- a/common/src/main/kotlin/org/imdc/extensions/common/PyDatasetBuilder.kt
+++ b/common/src/main/kotlin/org/imdc/extensions/common/PyDatasetBuilder.kt
@@ -1,0 +1,57 @@
+package org.imdc.extensions.common
+
+import com.inductiveautomation.ignition.common.Dataset
+import com.inductiveautomation.ignition.common.script.DisposablePyObjectAdapter
+import com.inductiveautomation.ignition.common.util.DatasetBuilder
+import com.inductiveautomation.ignition.common.xmlserialization.ClassNameResolver
+import org.python.core.Py
+import org.python.core.PyObject
+import org.python.core.adapter.PyObjectAdapter
+
+@Suppress("unused")
+class PyDatasetBuilder(private val builder: DatasetBuilder) : PyObject() {
+    private val resolver = ClassNameResolver.createBasic()
+
+    fun colNames(vararg names: String) = apply {
+        builder.colNames(names.toList())
+    }
+
+    fun colNames(names: List<String>) = apply {
+        builder.colNames(names)
+    }
+
+    fun colTypes(vararg types: String) = apply {
+        builder.colTypes(types.map { resolver.classForName(it) })
+    }
+
+    fun colTypes(vararg types: Class<*>?) = apply {
+        builder.colTypes(types.toList())
+    }
+
+    fun colTypes(types: List<Class<*>>) = apply {
+        builder.colTypes(types)
+    }
+
+    fun addRow(vararg values: Any?) = apply {
+        builder.addRow(*values)
+    }
+
+    fun build(): Dataset = builder.build()
+
+    companion object {
+        private val adapter = DisposablePyObjectAdapter(DatasetBuilderAdapter())
+
+        fun register() {
+            Py.getAdapter().addPostClass(adapter)
+        }
+
+        fun unregister() {
+            adapter.dispose()
+        }
+    }
+}
+
+class DatasetBuilderAdapter : PyObjectAdapter {
+    override fun adapt(o: Any?): PyObject = PyDatasetBuilder(o as DatasetBuilder)
+    override fun canAdapt(o: Any?): Boolean = o is DatasetBuilder
+}

--- a/common/src/main/kotlin/org/imdc/extensions/common/Utilities.kt
+++ b/common/src/main/kotlin/org/imdc/extensions/common/Utilities.kt
@@ -9,15 +9,15 @@ import java.lang.reflect.Method
 class PyObjectAppendable(target: PyObject) : Appendable {
     private val writeMethod = target.__getattr__("write")
 
-    override fun append(csq: CharSequence): Appendable = this.apply {
+    override fun append(csq: CharSequence?): Appendable = apply {
         writeMethod.__call__(Py.newStringOrUnicode(csq.toString()))
     }
 
-    override fun append(csq: CharSequence, start: Int, end: Int): Appendable = this.apply {
-        append(csq.subSequence(start, end))
+    override fun append(csq: CharSequence?, start: Int, end: Int): Appendable = apply {
+        append(csq.toString().subSequence(start, end))
     }
 
-    override fun append(c: Char): Appendable = this.apply {
+    override fun append(c: Char): Appendable = apply {
         append(c.toString())
     }
 }

--- a/common/src/main/resources/org/imdc/extensions/common/DatasetExtensions.properties
+++ b/common/src/main/resources/org/imdc/extensions/common/DatasetExtensions.properties
@@ -41,3 +41,8 @@ columnsEqual.param.dataset2=The second dataset. Must not be null.
 columnsEqual.param.ignoreCase=Pass True if the column names should be compared case-insensitive. Defaults to False.
 columnsEqual.param.includeTypes=Pass True if the column types must match as well. Defaults to True.
 columnsEqual.returns=True if the two datasets have the same columns, per additional parameters.
+
+builder.desc=Creates a new dataset using supplied column names and types.
+builder.param.**columns=Optional. Keyword arguments can be supplied to predefine column names and types. The value of the argument should be a Java or Python type.
+builder.returns=A DatasetBuilder object. Use <code>addRow(value, ...)</code> to add new values, and <code>build()</code> to construct the final dataset. \
+  If keyword arguments were not supplied, column names and types can be manually declared using <code>colNames()</code> and <code>colTypes()</code>.

--- a/common/src/main/resources/org/imdc/extensions/common/DatasetExtensions.properties
+++ b/common/src/main/resources/org/imdc/extensions/common/DatasetExtensions.properties
@@ -43,6 +43,6 @@ columnsEqual.param.includeTypes=Pass True if the column types must match as well
 columnsEqual.returns=True if the two datasets have the same columns, per additional parameters.
 
 builder.desc=Creates a new dataset using supplied column names and types.
-builder.param.**columns=Optional. Keyword arguments can be supplied to predefine column names and types. The value of the argument should be a Java or Python type.
+builder.param.**columns=Optional. Keyword arguments can be supplied to predefine column names and types. The value of the argument should be string "typecode" (see system.dataset.fromCSV) or a Java or Python class instance.
 builder.returns=A DatasetBuilder object. Use <code>addRow(value, ...)</code> to add new values, and <code>build()</code> to construct the final dataset. \
   If keyword arguments were not supplied, column names and types can be manually declared using <code>colNames()</code> and <code>colTypes()</code>.

--- a/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
+++ b/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
@@ -58,6 +58,8 @@ class DatasetExtensionsTests : JythonTest(
     }
 
     init {
+        PyDatasetBuilder.register()
+
         context("Map tests") {
             test("Null dataset") {
                 shouldThrowPyException(Py.TypeError) {
@@ -298,6 +300,23 @@ class DatasetExtensionsTests : JythonTest(
         context("Builder") {
             test("Basic usage") {
                 eval<Dataset>("utils.builder(a=int, b=str, c=bool).addRow(1, '2', False).build()").asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a",
+                        "b",
+                        "c",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Int::class.java,
+                        String::class.java,
+                        Boolean::class.java,
+                    )
+                }
+            }
+
+            test("String type codes") {
+                eval<Dataset>("utils.builder(a='i', b='str', c='b').addRow(1, '2', False).build()").asClue {
                     it.rowCount shouldBe 1
                     it.columnCount shouldBe 3
                     it.columnNames shouldBe listOf(

--- a/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
+++ b/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
@@ -7,6 +7,8 @@ import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import org.imdc.extensions.common.DatasetExtensions.printDataset
 import org.python.core.Py
+import java.awt.Color
+import java.util.Date
 import kotlin.io.path.createTempFile
 import kotlin.io.path.writeBytes
 
@@ -38,6 +40,9 @@ class DatasetExtensionsTests : JythonTest(
         }
         globals["xlsBytes"] = xlsSample
         globals["xlsFile"] = tempXls.toString()
+
+        globals["date"] = Date::class.java
+        globals["color"] = Color::class.java
     },
 ) {
     private fun Dataset.asClue(assertions: (Dataset) -> Unit) {
@@ -285,6 +290,156 @@ class DatasetExtensionsTests : JythonTest(
                         "Discounts",
                         "Sales",
                         "COGS",
+                    )
+                }
+            }
+        }
+
+        context("Builder") {
+            test("Basic usage") {
+                eval<Dataset>("utils.builder(a=int, b=str, c=bool).addRow(1, '2', False).build()").asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a",
+                        "b",
+                        "c",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Int::class.java,
+                        String::class.java,
+                        Boolean::class.java,
+                    )
+                }
+            }
+
+            test("Complex types") {
+                eval<Dataset>(
+                    """
+                    utils.builder(date=date, color=color, unicode=unicode) \
+                        .addRow(date(), color.RED, u'test') \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "date",
+                        "color",
+                        "unicode",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Date::class.java,
+                        Color::class.java,
+                        String::class.java,
+                    )
+                }
+            }
+
+            test("Nulls in rows") {
+                eval<Dataset>(
+                    """
+                    utils.builder(a=int, b=str, c=bool) \
+                        .addRow(1, '2', False) \
+                        .addRow(None, None, None) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 2
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a",
+                        "b",
+                        "c",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Int::class.java,
+                        String::class.java,
+                        Boolean::class.java,
+                    )
+                }
+            }
+
+            test("Empty dataset") {
+                eval<Dataset>("utils.builder().build()").asClue {
+                    it.rowCount shouldBe 0
+                    it.columnCount shouldBe 0
+                }
+            }
+
+            test("Add a row as a list") {
+                eval<Dataset>(
+                    """
+                    utils.builder(a=int, b=str, c=bool) \
+                        .addRow([1, '2', False]) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                }
+            }
+
+            test("Add a row as a tuple") {
+                eval<Dataset>(
+                    """
+                    utils.builder(a=int, b=str, c=bool) \
+                        .addRow((1, '2', False)) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                }
+            }
+
+            test("Columns with complex names") {
+                eval<Dataset>(
+                    """
+                    utils.builder(**{'a space': int, u'😍': bool, r',./;\'[]-=<>?:"{}|_+!@#%^&*()`~': str}) \
+                        .addRow((1, '2', False)) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a space",
+                        "\uD83D\uDE0D",
+                        """,./;\'[]-=<>?:"{}|_+!@#%^&*()`~""",
+                    )
+                }
+            }
+
+            test("Invalid types") {
+                shouldThrowPyException(Py.TypeError) {
+                    eval<Dataset>("utils.builder(a=1).build()")
+                }
+                shouldThrowPyException(Py.TypeError) {
+                    eval<Dataset>("utils.builder(a=None).build()")
+                }
+            }
+
+            test("Row without enough vararg values") {
+                shouldThrowPyException(Py.TypeError) {
+                    eval<Dataset>(
+                        """
+                        utils.builder(a=int, b=str, c=bool) \
+                            .addRow(1, '2') \
+                            .build()
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+            test("Row without enough list values") {
+                shouldThrowPyException(Py.TypeError) {
+                    eval<Dataset>(
+                        """
+                        utils.builder(a=int, b=str, c=bool) \
+                            .addRow([1, '2']) \
+                            .build()
+                        """.trimIndent(),
                     )
                 }
             }

--- a/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
+++ b/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
@@ -43,6 +43,9 @@ class DatasetExtensionsTests : JythonTest(
 
         globals["date"] = Date::class.java
         globals["color"] = Color::class.java
+        globals["javaInt"] = Int::class.java
+        globals["javaString"] = String::class.java
+        globals["javaBool"] = Boolean::class.java
     },
 ) {
     private fun Dataset.asClue(assertions: (Dataset) -> Unit) {
@@ -315,8 +318,83 @@ class DatasetExtensionsTests : JythonTest(
                 }
             }
 
-            test("String type codes") {
+            test("String type codes in builder call") {
                 eval<Dataset>("utils.builder(a='i', b='str', c='b').addRow(1, '2', False).build()").asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a",
+                        "b",
+                        "c",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Int::class.java,
+                        String::class.java,
+                        Boolean::class.java,
+                    )
+                }
+            }
+
+            test("Separate colTypes as java types") {
+                eval<Dataset>(
+                    """
+                    utils.builder() \
+                        .colNames('a', 'b', 'c') \
+                        .colTypes(javaInt, javaString, javaBool) \
+                        .addRow(1, '2', False) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a",
+                        "b",
+                        "c",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Int::class.java,
+                        String::class.java,
+                        Boolean::class.java,
+                    )
+                }
+            }
+
+            test("Separate colTypes as Python types") {
+                eval<Dataset>(
+                    """
+                    utils.builder() \
+                        .colNames('a', 'b', 'c') \
+                        .colTypes(int, str, bool) \
+                        .addRow(1, '2', False) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
+                    it.rowCount shouldBe 1
+                    it.columnCount shouldBe 3
+                    it.columnNames shouldBe listOf(
+                        "a",
+                        "b",
+                        "c",
+                    )
+                    it.columnTypes shouldBe listOf(
+                        Int::class.java,
+                        String::class.java,
+                        Boolean::class.java,
+                    )
+                }
+            }
+
+            test("Separate colTypes as string shortcodes") {
+                eval<Dataset>(
+                    """
+                    utils.builder() \
+                        .colNames('a', 'b', 'c') \
+                        .colTypes('i', 'str', 'b') \
+                        .addRow(1, '2', False) \
+                        .build()
+                    """.trimIndent(),
+                ).asClue {
                     it.rowCount shouldBe 1
                     it.columnCount shouldBe 3
                     it.columnNames shouldBe listOf(

--- a/designer/build.gradle.kts
+++ b/designer/build.gradle.kts
@@ -3,14 +3,10 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-    }
-}
-
 kotlin {
-    jvmToolchain(libs.versions.java.map(String::toInt).get())
+    jvmToolchain {
+        languageVersion.set(libs.versions.java.map(JavaLanguageVersion::of))
+    }
 }
 
 dependencies {

--- a/designer/src/main/kotlin/org/imdc/extensions/designer/DesignerHook.kt
+++ b/designer/src/main/kotlin/org/imdc/extensions/designer/DesignerHook.kt
@@ -8,6 +8,7 @@ import com.inductiveautomation.ignition.designer.model.AbstractDesignerModuleHoo
 import com.inductiveautomation.ignition.designer.model.DesignerContext
 import org.imdc.extensions.common.DatasetExtensions
 import org.imdc.extensions.common.ExtensionDocProvider
+import org.imdc.extensions.common.PyDatasetBuilder
 import org.imdc.extensions.common.UtilitiesExtensions
 import org.imdc.extensions.common.addPropertyBundle
 import org.imdc.extensions.common.expressions.IsAvailableFunction
@@ -24,6 +25,12 @@ class DesignerHook : AbstractDesignerModuleHook() {
             addPropertyBundle<UtilitiesExtensions>()
             addPropertyBundle<DesignerProjectExtensions>()
         }
+
+        PyDatasetBuilder.register()
+    }
+
+    override fun shutdown() {
+        PyDatasetBuilder.unregister()
     }
 
     override fun initializeScriptManager(manager: ScriptManager) {

--- a/gateway/build.gradle.kts
+++ b/gateway/build.gradle.kts
@@ -3,14 +3,10 @@ plugins {
     kotlin("jvm")
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(libs.versions.java.get()))
-    }
-}
-
 kotlin {
-    jvmToolchain(libs.versions.java.map(String::toInt).get())
+    jvmToolchain {
+        languageVersion.set(libs.versions.java.map(JavaLanguageVersion::of))
+    }
 }
 
 dependencies {

--- a/gateway/src/main/kotlin/org/imdc/extensions/gateway/GatewayHook.kt
+++ b/gateway/src/main/kotlin/org/imdc/extensions/gateway/GatewayHook.kt
@@ -8,6 +8,7 @@ import com.inductiveautomation.ignition.gateway.model.AbstractGatewayModuleHook
 import com.inductiveautomation.ignition.gateway.model.GatewayContext
 import org.imdc.extensions.common.DatasetExtensions
 import org.imdc.extensions.common.ExtensionDocProvider
+import org.imdc.extensions.common.PyDatasetBuilder
 import org.imdc.extensions.common.UtilitiesExtensions
 import org.imdc.extensions.common.addPropertyBundle
 import org.imdc.extensions.common.expressions.IsAvailableFunction
@@ -24,10 +25,14 @@ class GatewayHook : AbstractGatewayModuleHook() {
             addPropertyBundle<UtilitiesExtensions>()
             addPropertyBundle<GatewayProjectExtensions>()
         }
+
+        PyDatasetBuilder.register()
     }
 
     override fun startup(activationState: LicenseState) {}
-    override fun shutdown() {}
+    override fun shutdown() {
+        PyDatasetBuilder.unregister()
+    }
 
     override fun initializeScriptManager(manager: ScriptManager) {
         manager.apply {


### PR DESCRIPTION
Fixes #13 

Adds `system.dataset.builder()` that optionally accepts keyword arguments (ultimately, just exposing the Ignition builtin DatasetBuilder class more readily). Keyword arguments will be used to define the expected column names and types; Python types will be accepted, e.g. `system.dataset.builder(a=int, b=str, c=bool).addRow(1, '2', False).build()`.