### PR TITLE
Get rid of illegal reflective access warning

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,5 +17,6 @@ dependencies {
 tasks {
     withType<Test> {
         useJUnitPlatform()
+        jvmArgs = listOf("--add-opens", "java.base/java.io=ALL-UNNAMED")
     }
 }

--- a/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
+++ b/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
@@ -56,10 +56,12 @@ class DatasetExtensionsTests : JythonTest(
 ) {
     private fun Dataset.asClue(assertions: (Dataset) -> Unit) {
         withClue(
-            lazy {
-                buildString {
-                    printDataset(this, this@asClue, true)
-                }
+            {
+                lazy {
+                    buildString {
+                        printDataset(this, this@asClue, true)
+                    }
+                }.value
             },
         ) {
             assertions(this)

--- a/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
+++ b/common/src/test/kotlin/org/imdc/extensions/common/DatasetExtensionsTests.kt
@@ -57,11 +57,9 @@ class DatasetExtensionsTests : JythonTest(
     private fun Dataset.asClue(assertions: (Dataset) -> Unit) {
         withClue(
             {
-                lazy {
-                    buildString {
-                        printDataset(this, this@asClue, true)
-                    }
-                }.value
+                buildString {
+                    printDataset(this, this@asClue, true)
+                }
             },
         ) {
             assertions(this)


### PR DESCRIPTION
Resolves 
`WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.python.core.PySystemState (file:/C:/Users/user/.gradle/caches/modules-2/files-2.1/org.python/jython/2.7.1-ia5/3b60d0f70d44b56c14a9cb17bd499e3797df0a55/jython-2.7.1-ia5.jar) to method java.io.Console.encoding()
WARNING: Please consider reporting this to the maintainers of org.python.core.PySystemState
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
`
along with
`'withClue(Lazy<Any?>, () -> R): R' is deprecated. use withClue(lambda, lambda) instead`